### PR TITLE
Rework how winners are determined in tests that plays matches

### DIFF
--- a/Slask.SpecFlow.IntegrationTests/DomainTests/GroupTests/BracketGroup.feature
+++ b/Slask.SpecFlow.IntegrationTests/DomainTests/GroupTests/BracketGroup.feature
@@ -146,7 +146,7 @@ Scenario: Bracket progression goes as expected
 		And created groups within created tournament is played out and betted on
 			| Tournament index | Round index | Group index |
 			| 0                | 0           | 0           |
-	Then advancing players in created group 0 is exactly "Sixth"
+	Then advancing players in created group 0 is exactly "Eighth"
 		And participating players in group 0 should be mapped accordingly
 			| Match index | Player 1 name | Player 2 name |
 			| 0           | First         | Second        |
@@ -154,5 +154,5 @@ Scenario: Bracket progression goes as expected
 			| 2           | Fifth         | Sixth         |
 			| 3           | Seventh       | Eighth        |
 			| 4           | First         | Fourth        |
-			| 5           | Sixth         | Eighth        |
-			| 6           | First         | Sixth         |
+			| 5           | Fifth         | Eighth        |
+			| 6           | First         | Eighth        |

--- a/Slask.SpecFlow.IntegrationTests/DomainTests/GroupTests/DualTournamentGroup.feature
+++ b/Slask.SpecFlow.IntegrationTests/DomainTests/GroupTests/DualTournamentGroup.feature
@@ -51,11 +51,11 @@ Scenario: Dual tournament progression goes as expected
 	When created groups within created tournament is played out and betted on
 		| Tournament index | Round index | Group index |
 		| 0                | 0           | 0           |
-	Then advancing players in created group 0 is exactly "Fourth, First"
+	Then advancing players in created group 0 is exactly "First, Fourth"
 		And participating players in group 0 should be mapped accordingly
 			| Match index | Player 1 name | Player 2 name |
 			| 0           | First         | Second        |
 			| 1           | Third         | Fourth        |
 			| 2           | First         | Fourth        |
 			| 3           | Second        | Third         |
-			| 4           | First         | Third         |
+			| 4           | Fourth        | Second        |

--- a/Slask.SpecFlow.IntegrationTests/DomainTests/GroupTests/RoundRobinGroup.feature
+++ b/Slask.SpecFlow.IntegrationTests/DomainTests/GroupTests/RoundRobinGroup.feature
@@ -60,7 +60,7 @@ Scenario: Round robin progression with five players goes as expected
 	When created groups within created tournament is played out and betted on
 		| Tournament index | Round index | Group index |
 		| 0                | 0           | 0           |
-	Then advancing players in created group 0 is exactly "Fifth, Third, Second"
+	Then advancing players in created group 0 is exactly "Fifth, First, Fourth"
 		And participating players in group 0 should be mapped accordingly
 			| Match index | Player 1 name | Player 2 name |
 			| 0           | First         | Fourth        |

--- a/Slask.SpecFlow.IntegrationTests/DomainTests/RoundTests/Round.feature
+++ b/Slask.SpecFlow.IntegrationTests/DomainTests/RoundTests/Round.feature
@@ -14,7 +14,7 @@ Scenario: Can only exclude player references from groups within first round
 			| 0                | 0           | 0           |
 			| 0                | 0           | 1           |
 	When players "Rain" is excluded from round 1
-	Then participating players in round 1 should be exactly "Rain, Thorzain"
+	Then participating players in round 1 should be exactly "Maru, Bomber"
 
 Scenario: PlayState is set to NotBegun before any group has started
 	Given a tournament named "GSL 2019" has been created

--- a/Slask.SpecFlow.IntegrationTests/DomainTests/RoundTests/RoundInteraction.feature
+++ b/Slask.SpecFlow.IntegrationTests/DomainTests/RoundTests/RoundInteraction.feature
@@ -12,7 +12,7 @@ Scenario: Can fetch all winning players in a bracket round that contains several
 			| Tournament index | Round index | Group index |
 			| 0                | 0           | 0           |
 			| 0                | 0           | 1           |
-	Then fetched advancing players in created round 0 should be exactly "Fourth, Eighth"
+	Then fetched advancing players in created round 0 should be exactly "First, Eighth"
 
 @BracketRoundInteractionTag
 Scenario: Cannot fetch winning players from bracket group in a bracket round that has not played out
@@ -42,8 +42,8 @@ Scenario: A bracket round with a predecessor bracket round is set up using only 
 		| 0                | 0           | 3           |
 	Then participating players in group 4 should be mapped accordingly
 		| Match index | Player 1 name | Player 2 name |
-		| 0           | Fourth        | Eighth        |
-		| 1           | Twelfth       | Sixteenth     |
+		| 0           | First         | Eighth        |
+		| 1           | Eleventh      | Fifteenth     |
 
 @BracketRoundInteractionTag
 Scenario: A bracket round with a predecessor dual tournament round is set up using only winners of that predecessor round
@@ -76,8 +76,8 @@ Scenario: A bracket round with a predecessor round robin round is set up using o
 		| 0                | 0           | 1           |
 	Then participating players in group 2 should be mapped accordingly
 		| Match index | Player 1 name | Player 2 name |
-		| 0           | Fifth         | Second        |
-		| 1           | Tenth         | Seventh       |
+		| 0           | Fifth         | First         |
+		| 1           | Eighth        | Ninth         |
 
 ################################################################################################################
 
@@ -122,8 +122,8 @@ Scenario: A dual tournament round with a predecessor bracket round is set up usi
 		| 0                | 0           | 3           |
 	Then participating players in group 4 should be mapped accordingly
 		| Match index | Player 1 name | Player 2 name |
-		| 0           | Fourth        | Eighth        |
-		| 1           | Twelfth       | Sixteenth     |
+		| 0           | First         | Eighth        |
+		| 1           | Eleventh      | Fifteenth     |
 
 @DualTournamentRoundInteractionTag
 Scenario: A dual tournament round with a predecessor dual tournament round is set up using only winners of that predecessor round
@@ -156,8 +156,8 @@ Scenario: A dual tournament round with a predecessor round robin round is set up
 		| 0                | 0           | 1           |
 	Then participating players in group 2 should be mapped accordingly
 		| Match index | Player 1 name | Player 2 name |
-		| 0           | Fifth         | Second        |
-		| 1           | Tenth         | Seventh       |
+		| 0           | Fifth         | First         |
+		| 1           | Eighth        | Ninth         |
 
 ################################################################################################################
 
@@ -202,12 +202,12 @@ Scenario: A round robin round with a predecessor bracket round is set up using o
 		| 0                | 0           | 3           |
 	Then participating players in group 4 should be mapped accordingly
 		| Match index | Player 1 name | Player 2 name |
-		| 0           | Fourth        | Twelfth       |
-		| 1           | Eighth        | Sixteenth     |
-		| 2           | Fourth        | Sixteenth     |
-		| 3           | Twelfth       | Eighth        |
-		| 4           | Fourth        | Eighth        |
-		| 5           | Sixteenth     | Twelfth       |
+		| 0           | First         | Eleventh      |
+		| 1           | Eighth        | Fifteenth     |
+		| 2           | First         | Fifteenth     |
+		| 3           | Eleventh      | Eighth        |
+		| 4           | First         | Eighth        |
+		| 5           | Fifteenth     | Eleventh      |
 
 @RoundRobinRoundInteractionTag
 Scenario: A round robin round with a predecessor dual tournament round is set up using only winners of that predecessor round
@@ -244,9 +244,9 @@ Scenario: A round robin round with a predecessor round robin round is set up usi
 		| 0                | 0           | 1           |
 	Then participating players in group 2 should be mapped accordingly
 		| Match index | Player 1 name | Player 2 name |
-		| 0           | Fifth         | Tenth         |
-		| 1           | Second        | Seventh       |
-		| 2           | Fifth         | Seventh       |
-		| 3           | Tenth         | Second        |
-		| 4           | Fifth         | Second        |
-		| 5           | Seventh       | Tenth         |
+		| 0           | Fifth         | Eighth        |
+		| 1           | First         | Ninth         |
+		| 2           | Fifth         | Ninth         |
+		| 3           | Eighth        | First         |
+		| 4           | Fifth         | First         |
+		| 5           | Ninth         | Eighth        |

--- a/Slask.SpecFlow.IntegrationTests/DomainTests/TournamentSteps.cs
+++ b/Slask.SpecFlow.IntegrationTests/DomainTests/TournamentSteps.cs
@@ -21,8 +21,6 @@ namespace Slask.SpecFlow.IntegrationTests.DomainTests
 
     public class TournamentStepDefinitions : TournamentServiceStepDefinitions
     {
-        private Random randomizer;
-
         [Given(@"created tournament (.*) adds rounds")]
         [When(@"created tournament (.*) adds rounds")]
         public void GivenCreatedTournamentAddsRounds(int tournamentIndex, Table table)
@@ -151,8 +149,6 @@ namespace Slask.SpecFlow.IntegrationTests.DomainTests
                 }
 
                 SystemTimeMocker.Reset();
-                randomizer = new Random(133742069);
-
                 Tournament tournament = createdTournaments[tournamentIndex];
                 RoundBase round = tournament.Rounds[roundIndex];
                 GroupBase group = round.Groups[groupIndex];
@@ -297,7 +293,8 @@ namespace Slask.SpecFlow.IntegrationTests.DomainTests
 
                 if (matchShouldHaveStarted && matchIsNotFinished)
                 {
-                    bool increasePlayer1Score = randomizer.Next(2) == 0;
+                    // Give points to player with name that precedes the other
+                    bool increasePlayer1Score = match.Player1.Name.CompareTo(match.Player2.Name) <= 0;
 
                     if (increasePlayer1Score)
                     {

--- a/Slask.SpecFlow.IntegrationTests/DomainTests/UtilityTests/AdvancingPlayersSolver.feature
+++ b/Slask.SpecFlow.IntegrationTests/DomainTests/UtilityTests/AdvancingPlayersSolver.feature
@@ -11,7 +11,7 @@ Scenario: Can fetch advancing players from finished round
 	When created groups within created tournament is played out and betted on
 		| Tournament index | Round index | Group index |
 		| 0                | 0           | 0           |
-	Then advancing players from round 0 should be "Taeja, Rain, FanTaSy, Thorzain, Maru"
+	Then advancing players from round 0 should be "Bomber, FanTaSy, Maru, Rain, Stephano"
 
 Scenario: Can fetch advancing players from finished group
 	Given a tournament named "GSL 2019" has been created
@@ -22,7 +22,7 @@ Scenario: Can fetch advancing players from finished group
 	When created groups within created tournament is played out and betted on
 		| Tournament index | Round index | Group index |
 		| 0                | 0           | 0           |
-	Then advancing players from group 0 should be "Rain, Maru"
+	Then advancing players from group 0 should be "Maru, Rain"
 
 Scenario: Cannot fetch advancing players from round that is unfinished
 	Given a tournament named "GSL 2019" has been created

--- a/Slask.SpecFlow.IntegrationTests/DomainTests/UtilityTests/PlayerStandingsSolver.feature
+++ b/Slask.SpecFlow.IntegrationTests/DomainTests/UtilityTests/PlayerStandingsSolver.feature
@@ -11,4 +11,4 @@ Scenario: Fetches correctly ordered list of player standing entries
 	When created groups within created tournament is played out and betted on
 		| Tournament index | Round index | Group index |
 		| 0                | 0           | 0           |
-	Then player standings in group 0 from first to last should be "Taeja, Rain, FanTaSy, Thorzain, Maru, Bomber, Stork, Stephano"
+	Then player standings in group 0 from first to last should be "Bomber, FanTaSy, Maru, Rain, Stephano, Stork, Taeja, Thorzain"

--- a/Slask.SpecFlow.IntegrationTests/DomainTests/UtilityTests/PlayerSwitcher.feature
+++ b/Slask.SpecFlow.IntegrationTests/DomainTests/UtilityTests/PlayerSwitcher.feature
@@ -109,7 +109,7 @@ Scenario: Cannot switch player that resides in a bracket group with player in di
 		And participating players in group 2 should be mapped accordingly
 			| Match index | Player 1 name | Player 2 name |
 			| 0           | Maru          | Rain          |
-			| 1           | Bomber        | Thorzain      |
+			| 1           | Bomber        | FanTaSy       |
 
 Scenario: Cannot switch player that resides in a dual tournament group with player in different round
 	Given a tournament named "GSL 2019" has been created
@@ -139,7 +139,7 @@ Scenario: Cannot switch player that resides in a dual tournament group with play
 			| 0           | Stephano      | Thorzain      |
 		And participating players in group 4 should be mapped accordingly
 			| Match index | Player 1 name | Player 2 name |
-			| 0           | Maru          | Taeja         |
+			| 0           | Maru          | Rain          |
 			| 1           | Bomber        | Stephano      |
 
 Scenario: Cannot switch player that resides in a round robin group with player in different round
@@ -164,7 +164,7 @@ Scenario: Cannot switch player that resides in a round robin group with player i
 			| 1           | Stephano      | Thorzain      |
 		And participating players in group 2 should be mapped accordingly
 			| Match index | Player 1 name | Player 2 name |
-			| 0           | Rain          | Thorzain      |
+			| 0           | Maru          | Bomber        |
 
 Scenario: Cannot switch player with other player in same bracket group that has started
 	Given a tournament named "GSL 2019" has been created


### PR DESCRIPTION
Winner is selected by choosing the player with name that precedes the other, instead of selecting randomly